### PR TITLE
Added IRequestParameters DTO

### DIFF
--- a/src/HalKit/HalClient.cs
+++ b/src/HalKit/HalClient.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using HalKit.Http;
 using HalKit.Models;
+using HalKit.Models.Request;
 using HalKit.Models.Response;
 using HalKit.Services;
 
@@ -54,6 +55,11 @@ namespace HalKit
             return GetRootAsync(parameters, new Dictionary<string, IEnumerable<string>>());
         }
 
+        public Task<RootResource> GetRootAsync(IRequestParameters request)
+        {
+            return GetRootAsync(request.Parameters, request.Headers);
+        }
+
         public Task<RootResource> GetRootAsync(
             IDictionary<string, string> parameters,
             IDictionary<string, IEnumerable<string>> headers)
@@ -72,6 +78,11 @@ namespace HalKit
         public Task<T> GetAsync<T>(Link link, IDictionary<string, string> parameters)
         {
             return GetAsync<T>(link, parameters, new Dictionary<string, IEnumerable<string>>());
+        }
+
+        public Task<T> GetAsync<T>(Link link, IRequestParameters request)
+        {
+            return GetAsync<T>(link, request.Parameters, request.Headers);
         }
 
         public Task<T> GetAsync<T>(
@@ -95,6 +106,11 @@ namespace HalKit
         public Task<T> PostAsync<T>(Link link, object body, IDictionary<string, string> parameters)
         {
             return PostAsync<T>(link, body, parameters, new Dictionary<string, IEnumerable<string>>());
+        }
+
+        public Task<T> PostAsync<T>(Link link, object body, IRequestParameters request)
+        {
+            return PostAsync<T>(link, body, request.Parameters, request.Headers);
         }
 
         public Task<T> PostAsync<T>(
@@ -121,6 +137,11 @@ namespace HalKit
             return PutAsync<T>(link, body, parameters, new Dictionary<string, IEnumerable<string>>());
         }
 
+        public Task<T> PutAsync<T>(Link link, object body, IRequestParameters request)
+        {
+            return PutAsync<T>(link, body, request.Parameters, request.Headers);
+        }
+
         public Task<T> PutAsync<T>(
             Link link,
             object body,
@@ -145,6 +166,11 @@ namespace HalKit
             return PatchAsync<T>(link, body, parameters, new Dictionary<string, IEnumerable<string>>());
         }
 
+        public Task<T> PatchAsync<T>(Link link, object body, IRequestParameters request)
+        {
+            return PatchAsync<T>(link, body, request.Parameters, request.Headers);
+        }
+
         public Task<T> PatchAsync<T>(
             Link link,
             object body,
@@ -167,6 +193,11 @@ namespace HalKit
         public Task<IApiResponse> DeleteAsync(Link link, IDictionary<string, string> parameters)
         {
             return DeleteAsync(link, parameters, new Dictionary<string, IEnumerable<string>>());
+        }
+
+        public Task<IApiResponse> DeleteAsync(Link link, IRequestParameters request)
+        {
+            return DeleteAsync(link, request.Parameters, request.Headers);
         }
 
         public async Task<IApiResponse> DeleteAsync(

--- a/src/HalKit/HalClient.cs
+++ b/src/HalKit/HalClient.cs
@@ -4,7 +4,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using HalKit.Http;
 using HalKit.Models;
-using HalKit.Resources;
+using HalKit.Models.Response;
 using HalKit.Services;
 
 namespace HalKit

--- a/src/HalKit/HalKit.csproj
+++ b/src/HalKit/HalKit.csproj
@@ -35,17 +35,20 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="HalClient.cs" />
+    <Compile Include="Models\Response\CurieLink.cs" />
+    <Compile Include="Models\Response\Link.cs" />
+    <Compile Include="Models\Response\LinkCollection.cs" />
+    <Compile Include="Models\Response\Resource.cs" />
+    <Compile Include="Models\Response\RootResource.cs" />
     <Compile Include="Services\ILinkResolver.cs" />
     <Compile Include="Services\LinkResolver.cs" />
     <Compile Include="Http\HttpConnection.cs" />
     <Compile Include="Http\IHttpConnection.cs" />
     <Compile Include="IHalClient.cs" />
-    <Compile Include="Models\CurieLink.cs" />
     <Compile Include="Exceptions\LinkNotFoundException.cs" />
     <Compile Include="Json\DefaultJsonSerializer.cs" />
     <Compile Include="Json\EmbeddedAttribute.cs" />
     <Compile Include="Json\ResourceConverter.cs" />
-    <Compile Include="Models\LinkCollection.cs" />
     <Compile Include="Extensions\TaskExtensions.cs" />
     <Compile Include="HalKitConfiguration.cs" />
     <Compile Include="Http\ApiResponse.cs" />
@@ -55,15 +58,12 @@
     <Compile Include="Http\IHttpClientFactory.cs" />
     <Compile Include="IHalKitConfiguration.cs" />
     <Compile Include="Json\IJsonSerializer.cs" />
-    <Compile Include="Models\Link.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\..\SolutionInfo.cs">
       <Link>Properties\SolutionInfo.cs</Link>
     </Compile>
     <Compile Include="Http\HttpClientFactory.cs" />
     <Compile Include="Requires.cs" />
-    <Compile Include="Resources\Resource.cs" />
-    <Compile Include="Resources\RootResource.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <ItemGroup>

--- a/src/HalKit/HalKit.csproj
+++ b/src/HalKit/HalKit.csproj
@@ -35,6 +35,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="HalClient.cs" />
+    <Compile Include="Models\Request\IRequestParameters.cs" />
     <Compile Include="Models\Response\CurieLink.cs" />
     <Compile Include="Models\Response\Link.cs" />
     <Compile Include="Models\Response\LinkCollection.cs" />

--- a/src/HalKit/Http/ApiResponseFactory.cs
+++ b/src/HalKit/Http/ApiResponseFactory.cs
@@ -32,7 +32,7 @@ namespace HalKit.Http
                         body = await response.Content.ReadAsStringAsync().ConfigureAwait(_configuration);
                         if (body != null && IsJsonContent(response.Content))
                         {
-                            bodyAsObject = await _jsonSerializer.DeserializeAsync<T>(body).ConfigureAwait(_configuration);
+                            bodyAsObject = _jsonSerializer.Deserialize<T>(body);
                         }
                     }
                     else

--- a/src/HalKit/Http/HttpConnection.cs
+++ b/src/HalKit/Http/HttpConnection.cs
@@ -69,14 +69,14 @@ namespace HalKit.Http
 
                     request.Headers.Add(header.Key, header.Value);
                 }
-                request.Content = await GetRequestContentAsync(method, body, contentType);
+                request.Content = GetRequestContent(method, body, contentType);
 
                 var responseMessage = await _httpClient.SendAsync(request, CancellationToken.None).ConfigureAwait(_configuration);
                 return await _responseFactory.CreateApiResponseAsync<T>(responseMessage).ConfigureAwait(_configuration);
             }
         }
 
-        private async Task<HttpContent> GetRequestContentAsync(
+        private HttpContent GetRequestContent(
             HttpMethod method,
             object body,
             string contentType)
@@ -106,7 +106,7 @@ namespace HalKit.Http
             }
 
             // Anything else gets serialized to JSON
-            var bodyJson = await _jsonSerializer.SerializeAsync(body).ConfigureAwait(_configuration);
+            var bodyJson = _jsonSerializer.Serialize(body);
             return new StringContent(bodyJson, Encoding.UTF8, contentType);
         }
 

--- a/src/HalKit/IHalClient.cs
+++ b/src/HalKit/IHalClient.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using HalKit.Http;
-using HalKit.Models;
+using HalKit.Models.Request;
 using HalKit.Models.Response;
 
 namespace HalKit
@@ -12,6 +12,8 @@ namespace HalKit
 
         Task<RootResource> GetRootAsync(IDictionary<string, string> parameters);
 
+        Task<RootResource> GetRootAsync(IRequestParameters request);
+
         Task<RootResource> GetRootAsync(
             IDictionary<string, string> parameters,
             IDictionary<string, IEnumerable<string>> headers);
@@ -19,6 +21,8 @@ namespace HalKit
         Task<T> GetAsync<T>(Link link);
 
         Task<T> GetAsync<T>(Link link, IDictionary<string, string> parameters);
+
+        Task<T> GetAsync<T>(Link link, IRequestParameters request);
 
         Task<T> GetAsync<T>(
             Link link,
@@ -28,6 +32,11 @@ namespace HalKit
         Task<T> PostAsync<T>(Link link, object body);
 
         Task<T> PostAsync<T>(Link link, object body, IDictionary<string, string> parameters);
+
+        Task<T> PostAsync<T>(
+            Link link,
+            object body,
+            IRequestParameters request);
 
         Task<T> PostAsync<T>(
             Link link,
@@ -42,6 +51,11 @@ namespace HalKit
         Task<T> PutAsync<T>(
             Link link,
             object body,
+            IRequestParameters request);
+
+        Task<T> PutAsync<T>(
+            Link link,
+            object body,
             IDictionary<string, string> parameters,
             IDictionary<string, IEnumerable<string>> headers);
 
@@ -52,12 +66,19 @@ namespace HalKit
         Task<T> PatchAsync<T>(
             Link link,
             object body,
+            IRequestParameters request);
+
+        Task<T> PatchAsync<T>(
+            Link link,
+            object body,
             IDictionary<string, string> parameters,
             IDictionary<string, IEnumerable<string>> headers);
 
         Task<IApiResponse> DeleteAsync(Link link);
 
         Task<IApiResponse> DeleteAsync(Link link, IDictionary<string, string> parameters);
+
+        Task<IApiResponse> DeleteAsync(Link link, IRequestParameters request);
 
         Task<IApiResponse> DeleteAsync(
             Link link,

--- a/src/HalKit/IHalClient.cs
+++ b/src/HalKit/IHalClient.cs
@@ -2,7 +2,7 @@
 using System.Threading.Tasks;
 using HalKit.Http;
 using HalKit.Models;
-using HalKit.Resources;
+using HalKit.Models.Response;
 
 namespace HalKit
 {

--- a/src/HalKit/IHalKitConfiguration.cs
+++ b/src/HalKit/IHalKitConfiguration.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Threading;
-using HalKit.Resources;
+using HalKit.Models.Response;
 
 namespace HalKit
 {

--- a/src/HalKit/Json/DefaultJsonSerializer.cs
+++ b/src/HalKit/Json/DefaultJsonSerializer.cs
@@ -1,5 +1,4 @@
-﻿using System.Threading.Tasks;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace HalKit.Json
 {
@@ -13,16 +12,14 @@ namespace HalKit.Json
                 Converters = new[] { new ResourceConverter() }
             };
 
-        public Task<string> SerializeAsync(object value)
+        public string Serialize(object value)
         {
-            return Task.Factory.StartNew(
-                () => JsonConvert.SerializeObject(value, Settings));
+            return JsonConvert.SerializeObject(value, Settings);
         }
 
-        public Task<T> DeserializeAsync<T>(string json)
+        public T Deserialize<T>(string json)
         {
-            return Task.Factory.StartNew(
-                () => JsonConvert.DeserializeObject<T>(json, Settings));
+            return JsonConvert.DeserializeObject<T>(json, Settings);
         }
     }
 }

--- a/src/HalKit/Json/IJsonSerializer.cs
+++ b/src/HalKit/Json/IJsonSerializer.cs
@@ -1,10 +1,8 @@
-﻿using System.Threading.Tasks;
-
-namespace HalKit.Json
+﻿namespace HalKit.Json
 {
     public interface IJsonSerializer
     {
-        Task<string> SerializeAsync(object value);
-        Task<T> DeserializeAsync<T>(string json);
+        string Serialize(object value);
+        T Deserialize<T>(string json);
     }
 }

--- a/src/HalKit/Json/ResourceConverter.cs
+++ b/src/HalKit/Json/ResourceConverter.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using HalKit.Models;
-using HalKit.Resources;
+using HalKit.Models.Response;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 

--- a/src/HalKit/Models/Request/IRequestParameters.cs
+++ b/src/HalKit/Models/Request/IRequestParameters.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+
+namespace HalKit.Models.Request
+{
+    /// <summary>
+    /// Provides the query parameters and headers in a particular request.
+    /// </summary>
+    public interface IRequestParameters
+    {
+        /// <summary>
+        /// The query parameters to be used in a request
+        /// </summary>
+        IDictionary<string, string> Parameters { get; }
+
+        /// <summary>
+        /// The headers to be used in a request
+        /// </summary>
+        IDictionary<string, IEnumerable<string>> Headers { get; }
+    }
+}

--- a/src/HalKit/Models/Response/CurieLink.cs
+++ b/src/HalKit/Models/Response/CurieLink.cs
@@ -1,6 +1,6 @@
 ﻿using System.Runtime.Serialization;
 
-namespace HalKit.Models
+namespace HalKit.Models.Response
 {
     [DataContract]
     public class CurieLink : Link

--- a/src/HalKit/Models/Response/Link.cs
+++ b/src/HalKit/Models/Response/Link.cs
@@ -1,6 +1,6 @@
 ﻿using System.Runtime.Serialization;
 
-namespace HalKit.Models
+namespace HalKit.Models.Response
 {
     [DataContract]
     public class Link

--- a/src/HalKit/Models/Response/LinkCollection.cs
+++ b/src/HalKit/Models/Response/LinkCollection.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using HalKit.Exceptions;
 
-namespace HalKit.Models
+namespace HalKit.Models.Response
 {
     public class LinkCollection : IEnumerable<Link>
     {

--- a/src/HalKit/Models/Response/Resource.cs
+++ b/src/HalKit/Models/Response/Resource.cs
@@ -1,7 +1,6 @@
 ﻿using System.Runtime.Serialization;
-using HalKit.Models;
 
-namespace HalKit.Resources
+namespace HalKit.Models.Response
 {
     [DataContract]
     public class Resource

--- a/src/HalKit/Models/Response/RootResource.cs
+++ b/src/HalKit/Models/Response/RootResource.cs
@@ -1,6 +1,6 @@
 ﻿using System.Runtime.Serialization;
 
-namespace HalKit.Resources
+namespace HalKit.Models.Response
 {
     /// <summary>
     /// A <see cref="Resource"/> that acts as the "Home Page" of a Hypermedia-driven

--- a/src/HalKit/Services/ILinkResolver.cs
+++ b/src/HalKit/Services/ILinkResolver.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using HalKit.Models;
+using HalKit.Models.Response;
 
 namespace HalKit.Services
 {

--- a/src/HalKit/Services/LinkResolver.cs
+++ b/src/HalKit/Services/LinkResolver.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using HalKit.Models;
+using HalKit.Models.Response;
 using Tavis.UriTemplates;
 
 namespace HalKit.Services

--- a/tests/HalKit.Tests/HalClientTests.cs
+++ b/tests/HalKit.Tests/HalClientTests.cs
@@ -5,7 +5,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using HalKit.Http;
 using HalKit.Models;
-using HalKit.Resources;
+using HalKit.Models.Response;
 using HalKit.Services;
 using HalKit.Tests.Fakes;
 using Moq;

--- a/tests/HalKit.Tests/Http/ApiResponseFactoryTests.cs
+++ b/tests/HalKit.Tests/Http/ApiResponseFactoryTests.cs
@@ -111,7 +111,7 @@ namespace HalKit.Tests.Http
 
                 await factory.CreateApiResponseAsync<Foo>(new HttpResponseMessage() { Content = responseContent });
 
-                mockSerializer.Verify(j => j.DeserializeAsync<Foo>(It.IsAny<string>()), Times.Never());
+                mockSerializer.Verify(j => j.Deserialize<Foo>(It.IsAny<string>()), Times.Never());
             }
 
             [Theory, MemberData("JsonContentTypes")]
@@ -121,8 +121,8 @@ namespace HalKit.Tests.Http
                 var expectedJsonText = "{\"id\": 7}";
                 var responseContent = new StringContent(expectedJsonText, Encoding.UTF8, jsonContentType);
                 var mockSerializer = new Mock<IJsonSerializer>(MockBehavior.Loose);
-                mockSerializer.Setup(j => j.DeserializeAsync<Foo>(expectedJsonText))
-                              .Returns(Task.FromResult(new Foo()))
+                mockSerializer.Setup(j => j.Deserialize<Foo>(expectedJsonText))
+                              .Returns(new Foo())
                               .Verifiable();
                 var factory = CreateFactory(serializer: mockSerializer.Object);
 
@@ -138,7 +138,7 @@ namespace HalKit.Tests.Http
                 var expectedBodyAsObject = new Foo();
                 var responseContent = new StringContent("{}", Encoding.UTF8, jsonContentType);
                 var mockSerializer = new Mock<IJsonSerializer>(MockBehavior.Loose);
-                mockSerializer.Setup(j => j.DeserializeAsync<Foo>(It.IsAny<string>())).Returns(Task.FromResult(expectedBodyAsObject));
+                mockSerializer.Setup(j => j.Deserialize<Foo>(It.IsAny<string>())).Returns(expectedBodyAsObject);
                 var factory = CreateFactory(serializer: mockSerializer.Object);
 
                 var actualResponse = await factory.CreateApiResponseAsync<Foo>(new HttpResponseMessage() { Content = responseContent });

--- a/tests/HalKit.Tests/Json/DefaultJsonSerializerTests.cs
+++ b/tests/HalKit.Tests/Json/DefaultJsonSerializerTests.cs
@@ -1,5 +1,5 @@
 ﻿using HalKit.Json;
-using HalKit.Resources;
+using HalKit.Models.Response;
 using Xunit;
 
 namespace HalKit.Tests.Json

--- a/tests/HalKit.Tests/Json/DefaultJsonSerializerTests.cs
+++ b/tests/HalKit.Tests/Json/DefaultJsonSerializerTests.cs
@@ -27,24 +27,24 @@ namespace HalKit.Tests.Json
             public dynamic EmbeddedProperty { get; set; }
         }
 
-        public class TheDeserializeAsyncMethod
+        public class TheDeserializeMethod
         {
             [Fact]
-            public async void ShouldDeserializeEmbeddedProperty()
+            public void ShouldDeserializeEmbeddedProperty()
             {
                 var serializer = new DefaultJsonSerializer();
 
-                var foo = await serializer.DeserializeAsync<FooResource>(FooResourceJson);
+                var foo = serializer.Deserialize<FooResource>(FooResourceJson);
 
                 Assert.Equal("Expected embedded message", (string)foo.EmbeddedProperty.message);
             }
 
             [Fact]
-            public async void ShouldDeserializeLinnks()
+            public void ShouldDeserializeLinks()
             {
                 var serializer = new DefaultJsonSerializer();
 
-                var foo = await serializer.DeserializeAsync<FooResource>(FooResourceJson);
+                var foo = serializer.Deserialize<FooResource>(FooResourceJson);
 
                 Assert.Equal("http://api.com/resources/5", foo.Links["docs:some_resource"].HRef);
                 Assert.Equal("Some Resource", foo.Links["docs:some_resource"].Title);

--- a/tests/HalKit.Tests/Models/LinkCollectionTests.cs
+++ b/tests/HalKit.Tests/Models/LinkCollectionTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using HalKit.Exceptions;
 using HalKit.Models;
+using HalKit.Models.Response;
 using Xunit;
 
 namespace HalKit.Tests.Models

--- a/tests/HalKit.Tests/Services/LinkResolverTests.cs
+++ b/tests/HalKit.Tests/Services/LinkResolverTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using HalKit.Models;
+using HalKit.Models.Response;
 using HalKit.Services;
 using Xunit;
 


### PR DESCRIPTION
- Added an IRequestParameters DTO that represents the query params and headers that are being passed in a particular request. People building on top of HalKit can provide specific implementations of this interface to make it easier to pass parameters for their API endpoints
- Restructured the namespaces of the objects in Models/
- Made the IJsonSerializer interface synchronous