### PR TITLE
Allow relative links

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,6 @@
+### New in 1.0.3 (Released _)
+* Allow relative link uri
+
 ### New in 1.0 (Released 05/09/2018)
 * Upgrade packages to netstandard
 

--- a/Version.props
+++ b/Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.0.2</VersionPrefix>
+    <VersionPrefix>1.0.3</VersionPrefix>
     <VersionSuffix>
     </VersionSuffix>
   </PropertyGroup>

--- a/src/HalKit/HalClient.cs
+++ b/src/HalKit/HalClient.cs
@@ -362,8 +362,13 @@ namespace HalKit
                 headers.Add("Accept", new[] { HalJsonMediaType });
             }
 
+            
+            var uri = Configuration.AllowRelativeLinks
+                ? _linkResolver.ResolveLink(Configuration.RootEndpoint, link, parameters)
+                : _linkResolver.ResolveLink(link, parameters);
+
             return await HttpConnection.SendRequestAsync<T>(
-                        _linkResolver.ResolveLink(link, parameters),
+                        uri,
                         method,
                         body,
                         headers,

--- a/src/HalKit/HalKitConfiguration.cs
+++ b/src/HalKit/HalKitConfiguration.cs
@@ -19,6 +19,7 @@ namespace HalKit
         public Uri RootEndpoint { get; set; }
 
         public bool CaptureSynchronizationContext { get; set; }
+
         public bool AllowRelativeLinks { get; set; }
     }
 }

--- a/src/HalKit/HalKitConfiguration.cs
+++ b/src/HalKit/HalKitConfiguration.cs
@@ -19,5 +19,6 @@ namespace HalKit
         public Uri RootEndpoint { get; set; }
 
         public bool CaptureSynchronizationContext { get; set; }
+        public bool AllowRelativeLinks { get; set; }
     }
 }

--- a/src/HalKit/IHalKitConfiguration.cs
+++ b/src/HalKit/IHalKitConfiguration.cs
@@ -18,5 +18,10 @@ namespace HalKit
         /// </summary>
         /// <remarks>See http://blog.stephencleary.com/2012/02/async-and-await.html#avoiding-context.</remarks>
         bool CaptureSynchronizationContext { get; set; }
+
+        /// <summary>
+        /// Set whether relative links should be constructed from RootEndpoint
+        /// </summary>
+        bool AllowRelativeLinks { get; set; }
     }
 }

--- a/src/HalKit/Services/ILinkResolver.cs
+++ b/src/HalKit/Services/ILinkResolver.cs
@@ -16,5 +16,14 @@ namespace HalKit.Services
         /// Otherwise, the parameters are added to the href as query parameters.
         /// </summary>
         Uri ResolveLink(Link link, IDictionary<string, string> parameters);
+
+        /// <summary>
+        /// Resolves the href of the given <see cref="Link"/> with the given parameters to
+        /// get a <see cref="Uri"/>. If <paramref name="link"/> is templated then the parameters
+        /// are applied in accordance with Uri Template Spec RFC6570 (http://tools.ietf.org/html/rfc6570).
+        /// Otherwise, the parameters are added to the href as query parameters.
+        /// If the link is a relative Uri, it is then merged with the given rootEndpoint.
+        /// </summary>
+        Uri ResolveLink(Uri rootEndpoint, Link link, IDictionary<string, string> parameters);
     }
 }

--- a/src/HalKit/Services/LinkResolver.cs
+++ b/src/HalKit/Services/LinkResolver.cs
@@ -38,7 +38,7 @@ namespace HalKit.Services
 
             var templateParameters = parameters.ToDictionary(kv => kv.Key, kv => (object) kv.Value);
             var resolvedUrl = new UriTemplate(link.HRef).AddParameters(templateParameters).Resolve();
-            return new Uri(resolvedUrl, UriKind.RelativeOrAbsolute);
+            return new Uri(resolvedUrl);
         }
 
         private Uri AppendParametersAsQueryParams(


### PR DESCRIPTION
I ran into an API witih relative links, with some overlapping parts, i.e. `https://example.uri.com/endpoint`, containing links like `/endpoint/example/id`.
This resulted in some Uri exceptions, since it wasn't a proper full Uri.

It's optionally changed by setting the property `AllowRelativeLinks` in the `IHalKitConfiguration`, which results in the LinkResolver creating a new href from the relative path using the absolute path as base.

In the example, it takes the AbsolutePath from the example uri `/endpoint` and replaces it with the empty string, so the full AbsoluteUri can be joined with the remaining relative path `/example/id`.

